### PR TITLE
Make Lingua fully aware of the 'Accept-Language' header

### DIFF
--- a/lib/lingua.js
+++ b/lib/lingua.js
@@ -12,6 +12,92 @@ var fs = require('fs'),
     url = require('url'),
     Cookies = require('cookies');
 
+//
+//
+// summary:
+//     A class associating language tags with quality values
+//
+// description:
+//     A language tag identifies a language as described at
+//     <http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.10>
+//     (e.g. 'en-us'). A quality value (qvalue) determines the
+//     relative degree of preference for a language tag . Tags and
+//     qvalues are present in the HTTP Accept-Language header
+//     (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4)
+//     (e.g. 'Accept-Language: en-gb,en-us;q=0.7,en;q=0.3')
+//
+var TagSet = function TagSet() {
+    this.tagQvalues = {}; // associates 'q' values with language tags
+};
+
+//
+//
+// summary:
+//     Associate a tag with a qvalue
+//
+// description:
+//     More than one tag can be assigned to the same qvalue.
+//
+TagSet.prototype.addTag = function addTag(tag, qvalue) {
+    try {
+        this.tagQvalues[qvalue].push(tag);
+    } catch (e) {
+        if (!(e instanceof TypeError)) {
+            throw e;
+        }
+        this.tagQvalues[qvalue] = [tag];
+    }
+};
+
+//
+//
+// summary:
+//     Associate multiple tags with a qvalue
+//
+// description:
+//     A convenience method to save calling TagSet.addTag() multiple
+//     times.
+//
+TagSet.prototype.addTags = function addTag(tags, qvalue) {
+    try {
+        this.tagQvalues[qvalue].push.apply(this.tagQvalues[qvalue], tag);
+    } catch (e) {
+        if (!(e instanceof TypeError)) {
+            throw e;
+        }
+        this.tagQvalues[qvalue] = tags;
+    }
+};
+
+//
+//
+// summary:
+//     Get a list of all tags
+//
+// description:
+//     The list of tags is ordered by the associated tag qvalue in
+//     descending order.
+//
+TagSet.prototype.getTags = function getTags() {
+    // get the reverse ordered list of qvalues e.g. -> [1, 0.8, 0.5, 0.3]
+    var qvalues = [];
+    for (var qvalue in this.tagQvalues) {
+        if (this.tagQvalues.hasOwnProperty(qvalue)) {
+            qvalues.push(qvalue);
+        }
+    }
+    qvalues = qvalues.sort().reverse();
+
+    // add the tags to the tag list, ordered by qvalue
+    var tags = [];
+    var self = this;
+    qvalues.forEach(function(qvalue) {
+        tags.push.apply(tags, self.tagQvalues[qvalue]);
+    });
+
+    return tags;
+};
+
 module.exports = function(app, options) {
 
     var _name = 'lingua';
@@ -105,10 +191,18 @@ module.exports = function(app, options) {
         //     So if the "locale" is "de-de" then the guru will return
         //     the content which was defined in the "de-de.json" file.
         //
-        ask : function(locale) {
-            var resource = resources.filter(function(resource) {
-                return (resource.locale === locale);
-            })[0];
+        ask : function(locales) {
+
+            var resource, i;
+            for (i = 0; i < locales.length; i++) {
+                resource = resources.filter(function(resource) {
+                    return (resource.locale === locales[i]);
+                })[0];
+
+                if (resource) {
+                    break;
+                }
+            }
 
             if (!resource) {
                 resource = resources.filter(function(resource) {
@@ -133,38 +227,62 @@ module.exports = function(app, options) {
         //     Based on connect-i18n: https://github.com/masylum/connect-i18n/blob/master/lib/connect-i18n.js
         //
         determine : function(querystring, cookies, headers) {
-            var locale;
+            var locales = [];
 
             var query = querystring.query[CONSTANTS.storagekey];
             var cookiecream = cookies.get(CONSTANTS.storagekey);
 
             if (query) {
-                locale = query;
+                locales.push(query);
 
             } else if (cookiecream) {
-                locale = cookiecream;
+                locales.push(cookiecream);
 
             } else {
                 var acceptLanguage = headers['accept-language'];
-                var tokens = [];
-                var locales = [];
-
-                var result = null;
 
                 if (acceptLanguage) {
-                    acceptLanguage.split(',').forEach(function (lang) {
-                        locales.push(lang.split(';', 1)[0].toLowerCase());
+                    var tags = new TagSet();
+                    var subtags = new TagSet();
+
+                    // associate language tags by their 'q' qvalue (between 1 and 0)
+                    acceptLanguage.split(',').forEach(function(lang) {
+                        var parts = lang.split(';'); // 'en-GB;q=0.8' -> ['en-GB', 'q=0.8']
+                        var tag = parts.shift().toLowerCase().trim(); // ['en-GB', 'q=0.8'] -> 'en-gb'
+                        var primarySubtag = tag.split('-')[0].trimRight(); // 'en-gb' -> 'en'
+
+                        // get the language tag qvalue: 'q=0.8' -> 0.8
+                        var qvalue = 1; // default qvalue
+                        for (var i = 0; i < parts.length; i++) {
+                            var part = parts[i].split('=');
+                            if (part[0] === 'q' && !isNaN(part[1])) {
+                                qvalue = Number(part[1]);
+                                break;
+                            }
+                        }
+
+                        // add the tag and primary subtag to the qvalue associations
+                        tags.addTag(tag, qvalue);
+                        subtags.addTag(primarySubtag, qvalue);
                     });
 
-                    result = locales;
-                } else {
-                    result = [options.defaultLocale];
-                }
+                    // Add all the primary subtags to the tag set if
+                    // required, using a default low qvalue for the
+                    // primary subtags.
+                    var subtagQvalue = (isNaN(options.subtagQvalue)) ? 0.1 : options.subtagQvalue;
+                    if (subtagQvalue) {
+                        tags.addTags(subtags.getTags(), subtagQvalue);
+                    }
 
-                locale = result[0];
+                    // add the ordered list of tags to the locales
+                    locales.push.apply(locales, tags.getTags());
+
+                } else {
+                    locales.push(options.defaultLocale);
+                }
             }
 
-            return locale;
+            return locales;
         },
 
         //
@@ -268,13 +386,15 @@ module.exports = function(app, options) {
         // Determine the locale in this order:
         // 1. URL query string, 2. Cookie analysis, 3. header analysis
         //
-        var locale = guru.determine(query, cookies, headers);
+        var locales = guru.determine(query, cookies, headers);
+        var lingua = guru.ask(locales);
+        var locale = lingua.locale;
 
         var expirationDate = new Date();
         expirationDate.setFullYear(expirationDate.getFullYear() + 1);
         cookies.set(CONSTANTS.storagekey, locale, { expires: expirationDate });
 
-        res.lingua = guru.ask(locale);
+        res.lingua = lingua;
 
         next();
     };


### PR DESCRIPTION
This is a fix for issue #3. It means that Lingua now matches the best
available language tag in the Accept-Language header to a
resource. Previously only the first language tag in the header was
chosen as a locale.

In addition the subtagQvalue option to lingua has been added, with a
value range from 0 to 1 and defaulting to 0.1. If subtagQvalue is
non-zero then the primary subtag in a language tag is also extracted
and matched against a resource. In the language tag 'en-us' the
primary subtag is 'en'.

This change involved:
- creating code to extract and order the language tags and subtags
  based on qvalues.
- enhancing the guru.determines() method to return an ordered list of
  acceptable locales rather than a single locale.
- enhancing guru.ask() to take a list of locales rather than a single
  locale and try to a match a value in the list to a resource.
