### PR TITLE
Cookie settings aren't flexible enough

### DIFF
--- a/lib/lingua.js
+++ b/lib/lingua.js
@@ -26,7 +26,9 @@ module.exports = function (app, options) {
     config.storage = {
         key: options.storageKey || 'language'
     };
-    
+
+    config.cookieOptions = options.cookieOptions || {};
+
     config.resources = {
         path: options.path,
         defaultLocale: options.defaultLocale,

--- a/lib/trainee.js
+++ b/lib/trainee.js
@@ -136,11 +136,23 @@ module.exports = (function() {
     //
     Trainee.prototype.persistCookie = function(req, res, locale) {
         var cookies = new Cookies(req, res),
-            expirationDate = new Date();
+            expirationDate = new Date(),
+            options = this.configuration.cookieOptions;
 
         expirationDate.setFullYear(expirationDate.getFullYear() + 1);
 
-        cookies.set(this.configuration.storage.key, locale, { expires: expirationDate });
+        var cookieOptions = {
+            expires: expirationDate,
+            httpOnly: true
+        };
+
+        for(var property in options) {
+            if(options.hasOwnProperty(property)) {
+                cookieOptions[property] = options[property];
+            }
+        }
+
+        cookies.set(this.configuration.storage.key, locale, cookieOptions);
     };
 
     return Trainee;


### PR DESCRIPTION
Assuming that the locale cookie should be stored with the default path and domain is a little bit unwieldy, and prevents localization from working across subdomains, for example.

This pull request allows cookie options to be provided externally, overriding the current setting. The default is to use httpOnly cookies, but this can be overridden as well, which should resolve the issue knarz reported six months ago.
