### PR TITLE
Enable custom prefix helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Using lingua comes down with four simple steps:
 
         // Lingua configuration
         app.use(lingua(app, {
+            helperPrefix: 't',           // changes the view helper name
             defaultLocale: 'en',
             path: __dirname + '/i18n',
             storageKey: 'lang', // http://domain.tld/?lang=de

--- a/lib/lingua.js
+++ b/lib/lingua.js
@@ -115,8 +115,9 @@ module.exports = function (app, options) {
 
     // # Compatibility check
     if ('function' === typeof app.dynamicHelpers) { // Express < 3.0
+        var helper = config.resources.helperPrefix;
         app.dynamicHelpers({
-            lingua: function (req, res){
+          helper: function (req, res){
                 return res.lingua.content;
             }
         });

--- a/lib/lingua.js
+++ b/lib/lingua.js
@@ -33,7 +33,8 @@ module.exports = function (app, options) {
         path: options.path,
         defaultLocale: options.defaultLocale,
         extension: '.json',
-        placeholder: /\{(.*?)\}/
+        placeholder: /\{(.*?)\}/,
+        helperPrefix: options.helperPrefix || 'lingua'
     };
 
     //
@@ -121,7 +122,7 @@ module.exports = function (app, options) {
         });
     } else if ('function' === typeof app.locals.use) { // Express 3.0
         app.locals.use(function (req, res) {
-            res.locals.lingua = res.lingua.content;
+            res.locals[config.resources.helperPrefix] = res.lingua.content;
         });
     }
 
@@ -154,7 +155,7 @@ module.exports = function (app, options) {
 
         // # Compatibility check
         if ('function' === typeof app.locals) { // Express 3.0 RC
-            res.locals.lingua = res.lingua.content;
+            res.locals[config.resources.helperPrefix] = res.lingua.content;
         }
 
         next();


### PR DESCRIPTION
I wanted the ability to specify my own helper name, ex: `t` .. in order to do: `t.title` in my views instead of `lingua.title`.
